### PR TITLE
Fix failing GitHub Actions by adding httpx==0.23.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ sqlalchemy==2.0.15
 redis==4.5.5
 pytest==7.4.0
 flake8==6.1.0
+httpx==0.23.0
 


### PR DESCRIPTION
This PR fixes the failing GitHub Actions by adding httpx==0.23.0 to the requirements.txt file. The issue was caused by a version incompatibility between starlette and httpx, which was causing test failures.

Changes made:
- Added httpx==0.23.0 to requirements.txt to resolve TestClient compatibility issue
- Verified that all tests now pass with the updated requirements

This fix ensures that the CI/CD pipeline will pass the test stage successfully.